### PR TITLE
[feat] sc shopping 섹션 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import Main from '../components/Sections/Main'
 import TestDrive from '@/components/Sections/TestDrive'
+import SCShopping from '@/components/Sections/SCShopping'
 
 export default function Page() {
   const [username, setUsername] = useState<string>('Emma')
@@ -12,6 +13,7 @@ export default function Page() {
       <div className="flex flex-col gap-y-24">
         <Main />
         <TestDrive />
+        <SCShopping />
       </div>
     </div>
   )

--- a/src/components/Cards/ContentsCard.tsx
+++ b/src/components/Cards/ContentsCard.tsx
@@ -66,10 +66,10 @@ const sectionType: SectionStyle[] = [
       title: 'text-p26',
     },
     gap: {
-      image_categroy: 'pt-2',
-      category_title: 'pt-3',
+      image_categroy: 'pt-3',
+      category_title: 'pt-1',
     },
-    image_ratio: 'aspect-[334/235]',
+    image_ratio: 'aspect-[514/508]',
   },
   {
     section: 'latest',

--- a/src/components/Cards/ShoppingCard.tsx
+++ b/src/components/Cards/ShoppingCard.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+
+type ContentsCardProps = {
+  imageUrl: string
+  brand: string
+  product: string
+  price: string
+  store: string
+  link: string
+}
+
+export default function ShoppingCard({
+  imageUrl,
+  brand,
+  product,
+  price,
+  store,
+  link,
+}: ContentsCardProps) {
+  const router = useRouter()
+  const onClickCard = (link: string) => {
+    router.push(link)
+  }
+  return (
+    <div
+      className="flex h-full w-full cursor-pointer flex-col font-semibold gap-y-2"
+      onClick={() => onClickCard(link)}
+    >
+      {/* 이미지 영역 */}
+      <div className="relative w-full aspect-[187/254]">
+        <Image src={imageUrl} alt="thumbnail" fill className="object-cover" />
+      </div>
+
+      {/* 텍스트 영역 */}
+      <div className="flex flex-col gap-1 text-[12px] font-semibold">
+        <div className="">{brand}</div>
+        <div className="line-clamp-1 whitespace-pre-line break-words">{product}</div>
+        <div className="">{price}</div>
+        <div className="">{store}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Cards/ShoppingCard.tsx
+++ b/src/components/Cards/ShoppingCard.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import Image from 'next/image'
-import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 
-type ContentsCardProps = {
+type ShoppingCardProps = {
   imageUrl: string
   brand: string
   product: string
@@ -19,28 +19,27 @@ export default function ShoppingCard({
   price,
   store,
   link,
-}: ContentsCardProps) {
-  const router = useRouter()
-  const onClickCard = (link: string) => {
-    router.push(link)
-  }
+}: ShoppingCardProps) {
   return (
-    <div
+    <Link
+      rel="noopener noreferrer nofollow"
       className="flex h-full w-full cursor-pointer flex-col font-semibold gap-y-2"
-      onClick={() => onClickCard(link)}
+      href={link}
+      target="_blank"
+      aria-label={`${brand} ${product} - ${price} @ ${store}`}
     >
       {/* 이미지 영역 */}
       <div className="relative w-full aspect-[187/254]">
-        <Image src={imageUrl} alt="thumbnail" fill className="object-cover" />
+        <Image src={imageUrl} alt={`${brand} ${product}`} fill className="object-cover" />
       </div>
 
       {/* 텍스트 영역 */}
-      <div className="flex flex-col gap-1 text-[12px] font-semibold">
+      <div className="flex flex-col gap-1 text-[12px]">
         <div className="">{brand}</div>
         <div className="line-clamp-1 whitespace-pre-line break-words">{product}</div>
         <div className="">{price}</div>
         <div className="">{store}</div>
       </div>
-    </div>
+    </Link>
   )
 }

--- a/src/components/Sections/SCShopping.tsx
+++ b/src/components/Sections/SCShopping.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import ContentsCard from '../Cards/ContentsCard'
+import ShoppingCard from '../Cards/ShoppingCard'
+
+const shoppingData = {
+  products: [
+    {
+      id: 1,
+      brand: 'SUMMER FRIDAYS',
+      name: 'Lip Butter Balm',
+      price: '$24',
+      retailer: 'SEPHORA',
+      imageUrl: '/test/thumbnail_01.jpg',
+      link: 'https://www.amazon.com/%ED%99%94%EC%9E%A5%ED%92%88/s?k=%ED%99%94%EC%9E%A5%ED%92%88',
+    },
+    {
+      id: 2,
+      brand: 'FARMACY',
+      name: 'Lip Smoothie Peptide Lip Balm',
+      price: '$22',
+      retailer: 'AMAZON',
+      imageUrl: '/test/thumbnail_01.jpg',
+      link: 'https://www.amazon.com/%ED%99%94%EC%9E%A5%ED%92%88/s?k=%ED%99%94%EC%9E%A5%ED%92%88',
+    },
+    {
+      id: 3,
+      brand: 'NATURIUM',
+      name: 'Phyto-Glow Lip Balm',
+      price: '$10',
+      retailer: 'AMAZON',
+      imageUrl: '/test/thumbnail_01.jpg',
+      link: 'https://www.amazon.com/%ED%99%94%EC%9E%A5%ED%92%88/s?k=%ED%99%94%EC%9E%A5%ED%92%88',
+    },
+    {
+      id: 4,
+      brand: 'SUMMER FRIDAYS',
+      name: 'Lip Butter Balm',
+      price: '$24',
+      retailer: 'SEPHORA',
+      imageUrl: '/test/thumbnail_01.jpg',
+      link: 'https://www.amazon.com/%ED%99%94%EC%9E%A5%ED%92%88/s?k=%ED%99%94%EC%9E%A5%ED%92%88',
+    },
+    {
+      id: 5,
+      brand: 'FARMACY',
+      name: 'Lip Smoothie Peptide Lip Balm',
+      price: '$22',
+      retailer: 'AMAZON',
+      imageUrl: '/test/thumbnail_01.jpg',
+      link: 'https://www.amazon.com/%ED%99%94%EC%9E%A5%ED%92%88/s?k=%ED%99%94%EC%9E%A5%ED%92%88',
+    },
+    {
+      id: 6,
+      brand: 'NATURIUM',
+      name: 'Phyto-Glow Lip Balm',
+      price: '$10',
+      retailer: 'AMAZON',
+      imageUrl: '/test/thumbnail_01.jpg',
+      link: 'https://www.amazon.com/%ED%99%94%EC%9E%A5%ED%92%88/s?k=%ED%99%94%EC%9E%A5%ED%92%88',
+    },
+  ],
+}
+
+export default function SCShopping() {
+  return (
+    <div className="flex flex-col gap-y-10">
+      <div className="text-[30pt] border-b-[1.5px] border-black w-[400px] font-semibold">
+        SC SHOPPING
+      </div>
+      <div className="grid grid-cols-[1fr_1fr] gap-8">
+        <div>
+          <ContentsCard
+            section="shopping"
+            imageUrl="/test/thumbnail_01.jpg"
+            title={'Hailey Bieber’s Staple Fall\nJeans Are On Sale For Under $75'}
+            category="LIPS"
+          />
+        </div>
+        <div className="grid grid-cols-3 grid-rows-2 gap-5">
+          {shoppingData.products.map((item) => (
+            <ShoppingCard
+              key={item.id}
+              imageUrl={item.imageUrl}
+              brand={item.brand}
+              product={item.name}
+              price={item.price}
+              store={item.retailer}
+              link={item.link}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 💥 Related Issue
closed #11 

<br/>

## 📑 Summary
❶ ShoppingCard 컴포넌트를 구현했습니다. `imageUrl, brand, product, price, store, link` 정보를 props로 받아 관리합니다.
```ts
type ContentsCardProps = {
  imageUrl: string // 이미지 주소
  brand: string      // 브랜드
  product: string   // 제품 이름 
  price: string        // 가격
  store: string        // 판매처
  link: string           // 판매링크
}
```
❷ SCShopping 컴포넌트에서 섹션의 구조를 관리합니다. 
좌우 두개의 그리드를 1:1 비율로 나누고, 왼쪽에는 쇼핑 관련 콘텐츠를 크게 보여주며, 오른쪽에는 3x2 그리드에 6개의 쇼핑 아이템을 보여줍니다.
```ts
<div className="grid grid-cols-[1fr_1fr] gap-8">
     <div>{/* 쇼핑 관련 콘텐츠*/}</div>
     <div className="grid grid-cols-3 grid-rows-2 gap-5">
     </div>
</div>
```
쇼핑 아이템 관련 임의 테스트 데이터는 SCShopping 파일 상단에 더미데이터로 정의해두었습니다.



<br/>

## 🤳 Screenshots / Demo
![화면 기록 2025-09-06 오후 11 21 19](https://github.com/user-attachments/assets/52afdbd6-df7d-4717-90dd-6f011d8c7751)


<br/>

## 🗣️ Notes for Reviewers
**Link 속성**
- `noopener`
   - 새 창(target="_blank")에서 링크 열릴 때 window.opener 참조를 끊습니다.
   - 보안상 필요 (피싱 사이트가 원본 창을 조작 못하게 막음).

- `noreferrer`
   - 새 창으로 넘어갈 때 referrer(어떤 사이트에서 왔는지) 정보를 전달하지 않습니다.
   - 즉, 방문 사이트가 “이 링크가 어느 도메인에서 클릭됐는지” 알 수 없음.

- `nofollow`
   - SEO 관련.
   - 검색 엔진(구글 등)에 “이 링크는 신뢰 투표로 간주하지 말라”라고 알려줌.
   - 광고/스폰서/사용자 생성 콘텐츠(UGC) 등에 자주 붙임.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 쇼핑 섹션이 추가되어 메인 페이지에 노출됩니다.
  - 브랜드, 상품명, 가격, 판매처, 이미지로 구성된 클릭 가능한 카드 그리드(3x2)를 제공하며, 클릭 시 해당 링크로 이동합니다.
- 스타일
  - 쇼핑 섹션 카드의 상단 여백과 타이틀 간격을 조정하고 이미지 비율을 최적화하여 가독성과 시각적 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->