### PR TITLE
[feat] category 레이아웃 구현

### DIFF
--- a/src/app/[category]/page.tsx
+++ b/src/app/[category]/page.tsx
@@ -1,5 +1,8 @@
 import { notFound } from 'next/navigation'
 import { navItems } from '@/data/navItem'
+import Image from 'next/image'
+import ContentsCard from '@/components/Cards/ContentsCard'
+import { latestData } from '@/data/sectionData'
 
 export default async function CategoryPage({ params }: { params: Promise<{ category: string }> }) {
   const { category } = await params
@@ -13,30 +16,57 @@ export default async function CategoryPage({ params }: { params: Promise<{ categ
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="mb-6 text-3xl font-bold">{navItem.name}</h1>
+    <div className="container mb-24">
+      <div className="relative h-80 -mx-[5.375rem]">
+        <Image
+          src="/test/thumbnail_01.jpg"
+          alt={navItem.name}
+          fill
+          className="object-cover"
+          priority
+        />
+        {/* Content Overlay */}
+        <div className="absolute inset-0 flex flex-col justify-between py-8 left-[5.375rem]">
+          {/* Breadcrumb Navigation */}
+          <div className="flex items-center gap-2 text-white text-sm font-light tracking-wide">
+            <span className="uppercase">{navItem.name}</span>
+          </div>
+
+          <div className="mb-2">
+            <div className="text-white inline-block tracking-wide text-p32">
+              <div className="font-bold uppercase">{navItem.name}</div>
+            </div>
+          </div>
+        </div>
+      </div>
 
       {navItem.submenu && (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="flex gap-8 text-p12 py-5">
           {navItem.submenu.map((subItem) => (
             <div
               key={subItem.name}
-              className="rounded-lg border p-4 transition-shadow hover:shadow-md"
+              className="font-semibold cursor-pointer hover:underline hover:decoration-purple hover:decoration-[0.125rem] underline-offset-[0.4375rem]"
             >
-              <h2 className="mb-2 text-xl font-semibold">{subItem.name}</h2>
-              <p className="text-gray-600">{subItem.name}에 대한 상세 정보를 여기에 표시합니다.</p>
+              {subItem.name}
             </div>
           ))}
         </div>
       )}
 
-      {!navItem.submenu && (
-        <div className="py-12 text-center">
-          <p className="text-lg text-gray-600">
-            {navItem.name} 카테고리의 콘텐츠가 곧 추가될 예정입니다.
-          </p>
+      <div className="flex flex-col w-full mt-10">
+        <div className="text-p32 font-bold flex justify-center">THE LATEST</div>
+        <div className="grid grid-cols-3 grid-rows-2 gap-8 gap-y-14 mt-6">
+          {latestData.map((item) => (
+            <ContentsCard
+              key={item.id}
+              section={item.section}
+              title={item.title}
+              category={item.category}
+              imageUrl={item.imageUrl}
+            />
+          ))}
         </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,6 +32,7 @@ const config: Config = {
         p20: '1.667rem',
         p26: '2.167rem',
         p28: '2.333rem',
+        p32: '2.844rem',
         p50: '4.167rem',
       },
     },


### PR DESCRIPTION
## 💥 Related Issue
close #23 

<br/>

## 📑 Summary
category 페이지 레이아웃을 구현했습니다. 상단에 카테고리 썸네일이 위치하고 내부에 카테고리 이름을 표기합니다. 그 아래는 세부 카테고리로 이동하는 navbar가 존재합니다. navigation 연결은 추후에 contentful 모델링이 완료되면 진행할 예정입니다.
각 카테고리 페이지 내부에는 the latest 섹션이 존재합니다.

<br/>

## 🤳 Screenshots / Demo
<img width="1440" height="777" alt="스크린샷 2025-09-21 오후 11 49 42" src="https://github.com/user-attachments/assets/41087403-736c-4eaa-a2c3-75a65844f272" />

- 이미지는 test 이미지를 사용했습니다.

<br/>

## 🗣️ Notes for Reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 카테고리 페이지에 히어로 헤더(배경 이미지 + 오버레이 제목/라벨) 추가.
  * “THE LATEST” 최신 콘텐츠 섹션을 카드 그리드로 제공.

* 스타일
  * 서브메뉴를 가로형 인터랙티브 목록(밑줄/호버)으로 개선.
  * 레이아웃 컨테이너·그리드 조정으로 가독성과 시각적 위계 강화.
  * 새로운 폰트 크기 토큰(p32) 도입으로 타이포그래피 스케일 정교화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->