### PR TITLE
[style] 9/22 디자인 피드백 반영

### DIFF
--- a/src/app/[category]/page.tsx
+++ b/src/app/[category]/page.tsx
@@ -41,7 +41,7 @@ export default async function CategoryPage({ params }: { params: Promise<{ categ
       </div>
 
       {navItem.submenu && (
-        <div className="flex gap-8 text-p12 py-5">
+        <div className="flex gap-8 text-p14 py-5 pt-10">
           {navItem.submenu.map((subItem) => (
             <div
               key={subItem.name}

--- a/src/app/[category]/page.tsx
+++ b/src/app/[category]/page.tsx
@@ -40,6 +40,7 @@ export default async function CategoryPage({ params }: { params: Promise<{ categ
         </div>
       </div>
 
+      {/* 서브카테고리 네비게이션 */}
       {navItem.submenu && (
         <div className="flex gap-8 text-p14 py-5 pt-10">
           {navItem.submenu.map((subItem) => (
@@ -53,8 +54,9 @@ export default async function CategoryPage({ params }: { params: Promise<{ categ
         </div>
       )}
 
+      {/* 카테고리 콘텐츠 나열 3x2 */}
       <div className="flex flex-col w-full mt-10">
-        <div className="text-p32 font-bold flex justify-center">THE LATEST</div>
+        <div className="text-p32 font-semibold flex justify-center">THE LATEST</div>
         <div className="grid grid-cols-3 grid-rows-2 gap-8 gap-y-14 mt-6">
           {latestData.map((item) => (
             <ContentsCard

--- a/src/components/Cards/ContentsCard.tsx
+++ b/src/components/Cards/ContentsCard.tsx
@@ -88,7 +88,7 @@ export default function ContentsCard({ imageUrl, category, title, section }: Con
       <div className={`flex flex-col gap-1 ${style.gap.image_category}`}>
         <span className={`${style.font.category} text-[#464647] font-medium`}>{category}</span>
         <div
-          className={`${style.font.title} ${style.gap.category_title} tracking-[0.01em] line-clamp-2 whitespace-pre-line break-words ${style.section === 'main' ? 'leading-tight' : 'leading-snug'}`}
+          className={`${style.font.title} ${style.gap.category_title} tracking-[0.01em] line-clamp-2 whitespace-pre-line break-words leading-tight`}
         >
           {title}
         </div>

--- a/src/components/Carousel/CustomCarousel.tsx
+++ b/src/components/Carousel/CustomCarousel.tsx
@@ -70,7 +70,7 @@ export default function CustomCarousel({ category }: CarouselProps) {
       >
         {/* Header */}
         <div className="relative flex items-center justify-center border-b-[1.5px] border-black mb-6">
-          <h2 className="text-p28 font-bold">{category || 'CATEGORY'}</h2>
+          <h2 className="text-p28 font-semibold">{category || 'CATEGORY'}</h2>
           <div className="absolute right-0 flex">
             <CarouselPrevious className="border-none shadow-none static transform-none relative left-auto top-auto right-auto bottom-auto translate-x-0 translate-y-0" />
             <CarouselNext className="border-none shadow-none static transform-none relative left-auto top-auto right-auto bottom-auto translate-x-0 translate-y-0" />

--- a/src/components/Common/Footer.tsx
+++ b/src/components/Common/Footer.tsx
@@ -56,9 +56,9 @@ export default function Footer() {
             </div>
           </div>
 
-          <div className="grid w-full justify-between text-p13 lg:grid-cols-[auto_auto_auto] lg:gap-x-20">
+          <div className="grid w-full justify-between lg:grid-cols-[auto_auto_auto] lg:gap-x-20 font-poppins text-p12">
             {/* Navigation Links */}
-            <div className="w-fit text-p13">
+            <div className="w-fit">
               <nav className="flex flex-col space-y-3">
                 {mainNavLinks.map((item) => (
                   <Link
@@ -73,7 +73,7 @@ export default function Footer() {
             </div>
 
             {/* Company Links */}
-            <div className="w-fit text-p13">
+            <div className="w-fit">
               <nav className="flex flex-col gap-y-3">
                 {companyLinks.map((link) => (
                   <Link
@@ -88,7 +88,7 @@ export default function Footer() {
             </div>
 
             {/* Legal Links */}
-            <div className="w-fit text-p13">
+            <div className="w-fit">
               <nav className="flex flex-col gap-y-3">
                 {legalLinks.map((link) => (
                   <Link

--- a/src/components/Common/Navbar.tsx
+++ b/src/components/Common/Navbar.tsx
@@ -59,7 +59,7 @@ export default function Navbar({ showTopbar }: NavbarProps) {
               <NavigationMenuItem key={item.name}>
                 <NavigationMenuTrigger
                   onClick={() => onClickTrigger(item.href)}
-                  className="font-poppins tracking-wide cursor-pointer p-0 text-p12 underline-offset-[0.4375rem] hover:underline hover:decoration-purple hover:decoration-[0.125rem] data-[state=open]:underline data-[state=open]:decoration-purple data-[state=open]:decoration-[0.1rem] [&>svg]:hidden"
+                  className="font-poppins tracking-wide cursor-pointer p-0 text-p12 underline-offset-[0.4375rem] hover:underline hover:decoration-purple hover:decoration-[0.125rem] data-[state=open]:underline data-[state=open]:decoration-purple data-[state=open]:decoration-[0.125rem] [&>svg]:hidden"
                 >
                   {item.name}
                 </NavigationMenuTrigger>

--- a/src/components/Common/Navbar.tsx
+++ b/src/components/Common/Navbar.tsx
@@ -59,7 +59,7 @@ export default function Navbar({ showTopbar }: NavbarProps) {
               <NavigationMenuItem key={item.name}>
                 <NavigationMenuTrigger
                   onClick={() => onClickTrigger(item.href)}
-                  className="font-poppins tracking-wide cursor-pointer p-0 text-p12 underline-offset-[0.4375rem] hover:underline hover:decoration-purple hover:decoration-[0.1rem] data-[state=open]:underline data-[state=open]:decoration-purple data-[state=open]:decoration-[0.1rem] [&>svg]:hidden"
+                  className="font-poppins tracking-wide cursor-pointer p-0 text-p12 underline-offset-[0.4375rem] hover:underline hover:decoration-purple hover:decoration-[0.125rem] data-[state=open]:underline data-[state=open]:decoration-purple data-[state=open]:decoration-[0.1rem] [&>svg]:hidden"
                 >
                   {item.name}
                 </NavigationMenuTrigger>

--- a/src/data/navItem.ts
+++ b/src/data/navItem.ts
@@ -23,7 +23,6 @@ export const navItems: NavItem[] = [
       { name: 'Eyes', href: '/makeup/eyes' },
       { name: 'Lips', href: '/makeup/lips' },
       { name: 'Brushes & tools', href: '/makeup/brushes-tools' },
-      { name: 'View all', href: '/makeup/all' },
     ],
   },
   {


### PR DESCRIPTION
## 📑 Summary
9/22 디자인 피드백 수정 사항을 반영하였습니다.

**수정사항**
- contentscard title 줄간격 : section별로 조건부 스타일링하던 것을 `leading-tight`로 통일
- makeup subcategory에 존재하던 `view all` 항목 제거
- footer 네비게이션 항목들 `poppins` 폰트 적용 및 크기 변경 `p13` -> `p12`
- navbar underline decoration `0.125rem`으로 통일
- subcategory 네비게이션 스타일 변경
- 섹션 타이틀 font weight를 `semibold`로 통일

<br/>

## 🤳 Screenshots / Demo

<br/>

## 🗣️ Notes for Reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 서브카테고리 네비게이션 글꼴 크기와 여백 조정(텍스트 p14, 상단 패딩 추가).
  - THE LATEST 및 캐러셀 헤더 텍스트 굵기 bold → semibold로 조정.
  - 카드 타이틀 줄간격을 섹션과 무관하게 일관된 leading-tight로 통일.
  - 푸터 전체 폰트를 Poppins와 text-p12로 정리, 가독성 개선.
  - 네비게이션 메뉴 트리거의 밑줄 두께(hover/열림 상태) 소폭 증가.

- 작업(Chores)
  - MAKEUP 하위메뉴에서 “View all” 항목 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->